### PR TITLE
fix: bump goreleser config file version to 2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
-version: 1
+version: 2
 
 before:
   hooks:


### PR DESCRIPTION
Error from Github action
`only version: 2 configuration files are supported, yours is version: 1, please update your configuration`
